### PR TITLE
fix: Pin Docusaurus dependencies to specific versions

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,7 +18,7 @@
   "dependencies": {
     "@docusaurus/core": "3.4.0",
     "@docusaurus/preset-classic": "3.4.0",
-    "@docusaurus/theme-mermaid": "^3.4.0",
+    "@docusaurus/theme-mermaid": "3.4.0",
     "@mdx-js/react": "^3.0.0",
     "clsx": "^2.0.0",
     "date": "^2.0.5",
@@ -28,7 +28,7 @@
   },
   "devDependencies": {
     "@docusaurus/module-type-aliases": "3.4.0",
-    "@docusaurus/theme-classic": "^3.4.0",
+    "@docusaurus/theme-classic": "3.4.0",
     "@docusaurus/tsconfig": "3.4.0",
     "@docusaurus/types": "3.4.0",
     "@types/node": "^20.14.2",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -15,7 +15,7 @@ importers:
         specifier: 3.4.0
         version: 3.4.0(@algolia/client-search@4.24.0)(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(search-insights@2.15.0)(typescript@5.2.2)
       '@docusaurus/theme-mermaid':
-        specifier: ^3.4.0
+        specifier: 3.4.0
         version: 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@mdx-js/react':
         specifier: ^3.0.0
@@ -40,7 +40,7 @@ importers:
         specifier: 3.4.0
         version: 3.4.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@docusaurus/theme-classic':
-        specifier: ^3.4.0
+        specifier: 3.4.0
         version: 3.4.0(@types/react@18.3.3)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.2.2)
       '@docusaurus/tsconfig':
         specifier: 3.4.0


### PR DESCRIPTION
### Summary

**Type:** fix

* **What kind of change does this PR introduce?**
  * This PR introduces a change in the dependency management by pinning specific versions of Docusaurus dependencies in \`docs/package.json\` and \`docs/pnpm-lock.yaml\`.

* **What is the current behavior?**
  * Previously, the versions of \`@docusaurus/theme-mermaid\` and \`@docusaurus/theme-classic\` were set to use caret (^) versions, which allows minor updates.

* **What is the new behavior?**
  * With this PR, the versions of \`@docusaurus/theme-mermaid\` and \`@docusaurus/theme-classic\` are pinned to \`3.4.0\`. This ensures that only the specified version of the dependencies are used, preventing automatic updates that could potentially break compatibility or introduce bugs.

* **Does this PR introduce a breaking change?**
  * No breaking changes are introduced. However, users must be aware that dependency updates will now require manual changes to these version numbers in the future.

* **Has Testing been included for this PR?**
  * No additional tests have been added as this change only involves version numbers in package management files. Existing tests should pass as the versions specified are the ones previously in use.

### Other Information

This change helps in maintaining a stable and predictable build environment by avoiding unexpected updates through dependency version changes. It is a common practice to pin dependency versions in projects that require high stability.

----